### PR TITLE
bugfix for downModis._getToday()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Thanks to
 Anne Ghisla for help in code writing
 Markus Neteler and Markus Metz for testing
 Stefano Cavallari for bug fix
+Logan Byers for commenting
 
 Contact:
 


### PR DESCRIPTION
I have made improvements to pymodis.downmodis. These include a bugfix for the _getToday() method, and lots of edits to the comments for downmodis module

2014-08-21
BUG: if self.today or self.enday are not strings, i.e. they are
    datetime.date objects, then they could be passed to
    str2date() which would cause an error in that function.
    This could happen if, for example, self.getListDays() is
    called more than once.

FIX: changed 'if None: ... else: str2date()' statements to
    'if None: ... elif type() == str: str2date()'

A similar, and perhaps better way to fix this bug would be to
run the contents of _getToday() during __init__ and remove the
refernce to _getToday() inside getListDays(). However, this could
become a problem if self.today or self.enday are modified after
instantiation.

Also, raise an ImportError rather than raise a string.

2014-08-24
Changed much of the comments for downmodis module. These were mostly grammatical errors or unclear comments. Changed innerworkings of some member methods, but did not change input or output.

Changed the name of the private member functions _downloadsAllDayHTTP(self, days)  and _downloadsAllDayFTP. downloads->download, Day->Days.  This change is unimportant, and would not have been performed if the functions were intended to be public. Because they are private, I thought it was ok to change.

```
modified: pymodis/downmodis.py
--- _downloadsAllDayHTTP() -> _downloadAllDaysHTTP()
--- _downloadsAllDayFTP() -> _downloadAllDaysFTP()
modified: AUTHORS
```
