### PR TITLE
pymodis: use https for https://e4ftl01.cr.usgs.gov ; update pyModis homepage url

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -29,4 +29,4 @@ pyModis Development Team at the following address:
  38010 S. Michele all'Adige (Trento), Italy
  luca.delucchi AT fmach DOT it
 
-Internet:  http://pymodis.fem-environment.eu/
+Internet:  http://www.pymodis.org/

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Angelos Tzotsos <gcpp.kalxas@gmail.com>
 Build-Depends: debhelper (>= 7.0.50), python-setuptools (>= 0.6), python-support (>=0.6), python-all-dev (>= 2.3.5-11), python (>= 2.6.6-3)
 Standards-Version: 3.9.3
 X-Python-Version: >= 2.5
-Homepage: http://pymodis.fem-environment.eu/
+Homepage: http://www.pymodis.org/
 
 Package: python-pymodis
 Architecture: all

--- a/debian/copyright
+++ b/debian/copyright
@@ -33,4 +33,4 @@ pyModis Development Team at the following address:
  38010 S. Michele all'Adige (Trento), Italy
  luca.delucchi AT fmach DOT it
 
-Internet:  http://pymodis.fem-environment.eu/
+Internet:  http://www.pymodis.org/

--- a/docs/source/examples/pyModis.ipynb
+++ b/docs/source/examples/pyModis.ipynb
@@ -541,7 +541,7 @@
      "level": 3,
      "metadata": {},
      "source": [
-      "The tutorial is finished, you can find more info at <a href=\"http://pymodis.fem-environment.eu\" targe=\"_blank\">pyModis website</a>"
+      "The tutorial is finished, you can find more info at <a href=\"http://www.pymodis.org/\" targe=\"_blank\">pyModis website</a>"
      ]
     }
    ],

--- a/docs/source/scripts/modis_download.rst
+++ b/docs/source/scripts/modis_download.rst
@@ -23,7 +23,7 @@ Options
 ::
 
     -h  --help        shows the help message and exit
-    -u  --url         http/ftp server url [default=http://e4ftl01.cr.usgs.gov]
+    -u  --url         http/ftp server url [default=https://e4ftl01.cr.usgs.gov]
     -P  --password    password to connect (only if ftp server url)
     -U  --username    username to connect (only if ftp server url)
                       [default=anonymous]

--- a/docs/source/scripts/modis_download_from_list.rst
+++ b/docs/source/scripts/modis_download_from_list.rst
@@ -24,7 +24,7 @@ Options
 
     -h  --help        show the help message and exit
     -f  --file        Input file containing data to donwload
-    -u  --url         http/ftp server url [default=http://e4ftl01.cr.usgs.gov]
+    -u  --url         http/ftp server url [default=https://e4ftl01.cr.usgs.gov]
     -P  --password    password to connect only if ftp server
     -U  --username    username to connect only if ftp server
                       [default=anonymous]

--- a/pymodis/downmodis.py
+++ b/pymodis/downmodis.py
@@ -210,7 +210,7 @@ class downModis:
        :param bool checkgdal: variable to set the GDAL check
     """
     def __init__(self, destinationFolder, password=None, user="anonymous",
-                 url="http://e4ftl01.cr.usgs.gov", tiles=None, path="MOLT",
+                 url="https://e4ftl01.cr.usgs.gov", tiles=None, path="MOLT",
                  product="MOD11A1.005", today=None, enddate=None, delta=10,
                  jpg=False, debug=False, timeout=30, checkgdal=True):
         """Function to initialize the object"""

--- a/rpm/python-pymodis.spec
+++ b/rpm/python-pymodis.spec
@@ -26,7 +26,7 @@ Version:        0.7.4
 Release:        0
 Summary:        PyModis is a FOSS Python library to work with MODIS data
 License:        GPLv2+
-Url:            http://pymodis.fem-environment.eu
+Url:            http://www.pymodis.org/
 Group:          Productivity/Scientific/Other
 Source0:        %{pyname_cap}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/scripts/modis_download.py
+++ b/scripts/modis_download.py
@@ -39,7 +39,7 @@ def main():
         option_parser_class = optparse_required.OptionParser
     parser = option_parser_class(usage=usage, description='modis_download')
     # url
-    parser.add_option("-u", "--url", default="http://e4ftl01.cr.usgs.gov",
+    parser.add_option("-u", "--url", default="https://e4ftl01.cr.usgs.gov",
                       help="http/ftp server url [default=%default]",
                       dest="url")
     # password

--- a/scripts/modis_download_from_list.py
+++ b/scripts/modis_download_from_list.py
@@ -46,7 +46,7 @@ def main():
     parser.add_option("-f", "--file", dest="file", type='file',
                       help="Input file containing data to download")
     # url
-    parser.add_option("-u", "--url", default="http://e4ftl01.cr.usgs.gov",
+    parser.add_option("-u", "--url", default="https://e4ftl01.cr.usgs.gov",
                       help="http/ftp server url [default=%default]",
                       dest="url")
     # password


### PR DESCRIPTION
The https update is an attempt to get rid of the tons of warnings:

/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
