### PR TITLE
Updates for dockerized pyModis

### DIFF
--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -1,11 +1,13 @@
 FROM ubuntu:16.04
 
-# http://www.pymodis.org/ docker image
+# Dockerfile by M Neteler and L Delucchi
 
+# http://www.pymodis.org/
 MAINTAINER Luca Delucchi
 
 # system environment
 ENV DEBIAN_FRONTEND noninteractive
+WORKDIR /
 
 # fetch dependencies
 RUN apt-get update \
@@ -25,15 +27,13 @@ RUN apt-get autoremove && apt-get clean
 RUN pip install pyModis
 
 # make scripts available as dockerized applications
-ADD modis_download.py /modis_download.py
-ADD modis_download_from_list.py /modis_download_from_list.py
-ADD modis_convert.py /modis_convert.py
-ADD modis_mosaic.py /modis_mosaic.py
-ADD modis_parse.py /modis_parse.py
-ADD modis_multiparse.py /modis_multiparse.py
-ADD modis_quality.py /modis_quality.py
+ADD modis_download.py /
+ADD modis_download_from_list.py /
+ADD modis_convert.py /
+ADD modis_mosaic.py /
+ADD modis_parse.py /
+ADD modis_multiparse.py /
+ADD modis_quality.py /
 
 RUN chmod +x modis_download.py modis_download_from_list.py modis_convert.py modis_mosaic.py modis_parse.py modis_multiparse.py modis_quality.py
-
-WORKDIR /
 

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -25,4 +25,6 @@ RUN apt-get autoremove && apt-get clean
 # Install pyModis
 RUN pip install pyModis
 
-ENTRYPOINT ["python", "/usr/local/bin/modis_download.py"]
+# where to store the MODIS data, run the container using -v /path/on/host:/export to access directory
+VOLUME ["/export"]
+ENTRYPOINT ["python", "/usr/local/bin/modis_download.py", "/export"]

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -25,15 +25,4 @@ RUN apt-get autoremove && apt-get clean
 # Install pyModis
 RUN pip install pyModis
 
-# make scripts available as dockerized applications
-ADD /usr/local/bin/modis_download.py /
-ADD /usr/local/bin/modis_download_from_list.py /
-ADD /usr/local/bin/modis_convert.py /
-ADD /usr/local/bin/modis_mosaic.py /
-ADD /usr/local/bin/modis_parse.py /
-ADD /usr/local/bin/modis_multiparse.py /
-ADD /usr/local/bin/modis_quality.py /
-
-WORKDIR /
-RUN chmod +x modis_download.py modis_download_from_list.py modis_convert.py modis_mosaic.py modis_parse.py modis_multiparse.py modis_quality.py
-
+ENTRYPOINT ["python", "/usr/local/bin/modis_download.py"]

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -6,10 +6,6 @@ MAINTAINER Luca Delucchi
 
 # system environment
 ENV DEBIAN_FRONTEND noninteractive
-#### ENV CPLUS_INCLUDE_PATH=/usr/include/gdal \
-####    C_INCLUDE_PATH=/usr/include/gdal
-
-# ??     && apt-get install -y --install-recommends \
 
 # fetch dependencies
 RUN apt-get update \
@@ -23,9 +19,7 @@ RUN apt-get update \
     python-future \
     python-requests
 
-#    && apt-get autoremove \
-#    && apt-get clean
+RUN apt-get autoremove && apt-get clean
 
 # Install pyModis
-#####? RUN pip install GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}')
 RUN pip install pyModis

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -7,7 +7,6 @@ MAINTAINER Luca Delucchi
 
 # system environment
 ENV DEBIAN_FRONTEND noninteractive
-WORKDIR /
 
 # fetch dependencies
 RUN apt-get update \
@@ -27,13 +26,14 @@ RUN apt-get autoremove && apt-get clean
 RUN pip install pyModis
 
 # make scripts available as dockerized applications
-ADD modis_download.py /
-ADD modis_download_from_list.py /
-ADD modis_convert.py /
-ADD modis_mosaic.py /
-ADD modis_parse.py /
-ADD modis_multiparse.py /
-ADD modis_quality.py /
+ADD /usr/local/bin/modis_download.py /
+ADD /usr/local/bin/modis_download_from_list.py /
+ADD /usr/local/bin/modis_convert.py /
+ADD /usr/local/bin/modis_mosaic.py /
+ADD /usr/local/bin/modis_parse.py /
+ADD /usr/local/bin/modis_multiparse.py /
+ADD /usr/local/bin/modis_quality.py /
 
+WORKDIR /
 RUN chmod +x modis_download.py modis_download_from_list.py modis_convert.py modis_mosaic.py modis_parse.py modis_multiparse.py modis_quality.py
 

--- a/docker/python2/Dockerfile
+++ b/docker/python2/Dockerfile
@@ -23,3 +23,17 @@ RUN apt-get autoremove && apt-get clean
 
 # Install pyModis
 RUN pip install pyModis
+
+# make scripts available as dockerized applications
+ADD modis_download.py /modis_download.py
+ADD modis_download_from_list.py /modis_download_from_list.py
+ADD modis_convert.py /modis_convert.py
+ADD modis_mosaic.py /modis_mosaic.py
+ADD modis_parse.py /modis_parse.py
+ADD modis_multiparse.py /modis_multiparse.py
+ADD modis_quality.py /modis_quality.py
+
+RUN chmod +x modis_download.py modis_download_from_list.py modis_convert.py modis_mosaic.py modis_parse.py modis_multiparse.py modis_quality.py
+
+WORKDIR /
+

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -6,10 +6,6 @@ MAINTAINER Luca Delucchi
 
 # system environment
 ENV DEBIAN_FRONTEND noninteractive
-#### ENV CPLUS_INCLUDE_PATH=/usr/include/gdal \
-####    C_INCLUDE_PATH=/usr/include/gdal
-
-# ??     && apt-get install -y --install-recommends \
 
 # fetch dependencies
 RUN apt-get update \
@@ -23,9 +19,7 @@ RUN apt-get update \
     python3-future \
     python3-requests
 
-#    && apt-get autoremove \
-#    && apt-get clean
+RUN apt-get autoremove && apt-get clean
 
 # Install pyModis
-#####? RUN pip install GDAL==$(gdal-config --version | awk -F'[.]' '{print $1"."$2}')
 RUN pip3 install pyModis

--- a/docker/python3/Dockerfile
+++ b/docker/python3/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu:16.04
 
-# http://www.pymodis.org/ docker image
+# Dockerfile by M Neteler and L Delucchi
 
+# http://www.pymodis.org/
 MAINTAINER Luca Delucchi
 
 # system environment
@@ -23,3 +24,7 @@ RUN apt-get autoremove && apt-get clean
 
 # Install pyModis
 RUN pip3 install pyModis
+
+# where to store the MODIS data, run the container using -v /path/on/host:/export to access directory
+VOLUME ["/export"]
+ENTRYPOINT ["python3", "/usr/local/bin/modis_download.py", "/export"]


### PR DESCRIPTION
# fetch image
sudo docker pull neteler/pymodis

# run them all:
## note the .py:
sudo docker run -it --rm  neteler/pymodis modis_download.py --help
sudo docker run -it --rm  neteler/pymodis modis_download_from_list.py --help
sudo docker run -it --rm  neteler/pymodis modis_convert.py --help
sudo docker run -it --rm  neteler/pymodis modis_mosaic.py --help
sudo docker run -it --rm  neteler/pymodis modis_parse.py --help
sudo docker run -it --rm  neteler/pymodis modis_multiparse.py --help
sudo docker run -it --rm  neteler/pymodis modis_quality.py --help

More changes are apparently needed since the scripts do not find the destination_folder yet.