### PR TITLE
Handle multibands files (like MCD19A2 v006)

### DIFF
--- a/pymodis/convertmodis_gdal.py
+++ b/pymodis/convertmodis_gdal.py
@@ -244,7 +244,7 @@ class convertModisGDAL:
             out_name = "{pref}.tif".format(pref=self.output_pref)
         try:
             dst_ds = self.driver.Create(out_name, self.dst_xsize,
-                                        self.dst_ysize, 1, datatype)
+                                        self.dst_ysize, l_src_ds.RasterCount, datatype)
         except:
             raise Exception('Not possible to create dataset %s' % out_name)
         dst_ds.SetProjection(self.dst_wkt)


### PR DESCRIPTION
This PR allows pyModis library handling multichannel products. See related https://github.com/OSGeo/grass-addons/pull/178.

## Input

```
gdalinfo HDF4_EOS:EOS_GRID:"/home/landa/shares/geoharmonizer/AirQuality/MODIS/MCD19A2/Test1/MCD19A2.A2020001.h18v03.006.2020003034742.hdf":grid1km:Optical_Depth_055
...
Band 1 Block=1200x833 Type=Int16, ColorInterp=Gray
...
Band 5 Block=1200x833 Type=Int16, ColorInterp=Gray
```

## Current behaviour

PyModis processes the first band only.

```
MCD19A2.A2020121_mosaic_Optical_Depth_055
```

## Expected behaviour

PyModis should process all the bands.

```
MCD19A2.A2020121_mosaic_Optical_Depth_055.1
MCD19A2.A2020121_mosaic_Optical_Depth_055.2
MCD19A2.A2020121_mosaic_Optical_Depth_055.3
MCD19A2.A2020121_mosaic_Optical_Depth_055.4
MCD19A2.A2020121_mosaic_Optical_Depth_055.5
MCD19A2.A2020121_mosaic_Optical_Depth_055.6
```
