### PR TITLE
Fix year used in downModis.removeEmptyFiles()

### DIFF
--- a/pymodis/downmodis.py
+++ b/pymodis/downmodis.py
@@ -360,12 +360,14 @@ class downModis:
         elif GDAL and not checkgdal:
             GDAL = False
         self.dirData = []
+        # set today and enday dates
+        self._getToday()
 
     def removeEmptyFiles(self):
         """Function to remove files in the download directory that have
            filesize equal to 0
         """
-        year = str(date.today().year)
+        year = str(self.today.year)
         prefix = self.product.split('.')[0]
         files = glob.glob1(self.writeFilePath, '%s.A%s*' % (prefix, year))
         for f in files:
@@ -496,8 +498,6 @@ class downModis:
 
     def getListDays(self):
         """Return a list of all selected days"""
-        self._getToday()
-
         today_s = self.today.strftime("%Y.%m.%d")
         # dirData is reverse sorted
         for i, d in enumerate(self.dirData):


### PR DESCRIPTION
The year being set in `downModis.removeEmptyFiles()` is causing the function to only work for files matching the current year.

I fixed the function to instead pull the year from `self.today` which also required the `self._getToday()` call to happen earlier. I couldn't see any reason for it to not be called in the constructor so I moved it there.

This makes it so the function moves closer to what one would expect I think as it will remove all empty files matching the year of the `self.today`. This works fine for my use case as I'm downloading each date in its own directory so this is sufficient. However, I don't see why the year is being used instead of the full date and why only `today` is considered instead of the full date range.

I think this function could be improved by having it either:
* Delete all empty files for each specified date, regardless of what else is in the directory.
* Delete all empty files in the directory, regardless of date.

I'm not sure what would be best but an update to the docs would also be good regardless of which one is implemented.