### PR TITLE
Added bearer token authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Sphinx's builds
 /docs/build
+
+# Visual Studio Code
+.vscode/

--- a/pymodis/downmodis.py
+++ b/pymodis/downmodis.py
@@ -259,40 +259,44 @@ class downModis:
             self.urltype = 'http'
         else:
             raise IOError("The url should contain 'ftp://' or 'http://'")
-        if (not user and not password and not URLPARSE) and not token:
-            raise IOError("Please use 'user' and 'password' or 'token' parameters")
-        elif not user and not password and URLPARSE:
-            self.domain = urlparse(self.url).hostname
-            try:
-                nt = netrc.netrc()
-            except:
-                raise IOError("Please set 'user' and 'password' parameters"
-                              ", netrc file does not exist")
-            try:
-                account = nt.hosts[self.domain]
-            except:
-                try:
-                    account = nt.hosts['urs.earthdata.nasa.gov']
-                except:
-                    raise IOError("Please set 'user' and 'password' parameters"
-                                  ", netrc file does not contain parameter "
-                                  "for NASA url")
-            # user for download
-            self.user = account[0]
-            # password for download
-            self.password = account[2]
-        else:
-            # user for download
-            self.user = user
-            # password for download
-            self.password = password
+
+        if (not user and not password and not token) or (user and password):
+            raise IOError("You must provide either a token or a user and password")
+
+        if token: 
             # token for download
             self.token = token
-        self.userpwd = "{us}:{pw}".format(us=self.user,
-                                          pw=self.password)
-        if not token is None: 
-            self.http_header = {'Authorization': f"Bearer {token}"}
+            self.http_header = {'Authorization': f"Bearer {self.token}"}
         else:
+            if (not user and not password and not URLPARSE):
+                raise IOError("Please use 'user' and 'password' parameters")
+            elif not user and not password and URLPARSE:
+                self.domain = urlparse(self.url).hostname
+                try:
+                    nt = netrc.netrc()
+                except:
+                    raise IOError("Please set 'user' and 'password' parameters"
+                                ", netrc file does not exist")
+                try:
+                    account = nt.hosts[self.domain]
+                except:
+                    try:
+                        account = nt.hosts['urs.earthdata.nasa.gov']
+                    except:
+                        raise IOError("Please set 'user' and 'password' parameters"
+                                    ", netrc file does not contain parameter "
+                                    "for NASA url")
+                # user for download
+                self.user = account[0]
+                # password for download
+                self.password = account[2]
+            else:
+                # user for download
+                self.user = user
+                # password for download
+                self.password = password
+            
+            self.userpwd = "{us}:{pw}".format(us=self.user, pw=self.password)
             userAndPass = b64encode(str.encode(self.userpwd)).decode("ascii")
             self.http_header = {'Authorization': 'Basic %s' %  userAndPass}
 

--- a/pymodis/downmodis.py
+++ b/pymodis/downmodis.py
@@ -241,7 +241,7 @@ class downModis:
        :param bool checkgdal: variable to set the GDAL check
     """
 
-    def __init__(self, destinationFolder, password=None, user=None,
+    def __init__(self, destinationFolder, password=None, user=None, token=None,
                  url="https://e4ftl01.cr.usgs.gov", tiles=None, path="MOLT",
                  product="MOD11A1.006", today=None, enddate=None, delta=10,
                  jpg=False, debug=False, timeout=30, checkgdal=True):
@@ -259,8 +259,8 @@ class downModis:
             self.urltype = 'http'
         else:
             raise IOError("The url should contain 'ftp://' or 'http://'")
-        if not user and not password and not URLPARSE:
-            raise IOError("Please use 'user' and 'password' parameters")
+        if (not user and not password and not URLPARSE) and not token:
+            raise IOError("Please use 'user' and 'password' or 'token' parameters")
         elif not user and not password and URLPARSE:
             self.domain = urlparse(self.url).hostname
             try:
@@ -286,10 +286,16 @@ class downModis:
             self.user = user
             # password for download
             self.password = password
+            # token for download
+            self.token = token
         self.userpwd = "{us}:{pw}".format(us=self.user,
                                           pw=self.password)
-        userAndPass = b64encode(str.encode(self.userpwd)).decode("ascii")
-        self.http_header = {'Authorization': 'Basic %s' %  userAndPass}
+        if not token is None: 
+            self.http_header = {'Authorization': f"Bearer {token}"}
+        else:
+            userAndPass = b64encode(str.encode(self.userpwd)).decode("ascii")
+            self.http_header = {'Authorization': 'Basic %s' %  userAndPass}
+
         cookieprocessor = urllib.request.HTTPCookieProcessor()
         opener = urllib.request.build_opener(ModisHTTPRedirectHandler,
                                              cookieprocessor)

--- a/pymodis/downmodis.py
+++ b/pymodis/downmodis.py
@@ -260,7 +260,7 @@ class downModis:
         else:
             raise IOError("The url should contain 'ftp://' or 'http://'")
 
-        if (not user and not password and not token) or (user and password):
+        if not user and not password and not token:
             raise IOError("You must provide either a token or a user and password")
 
         if token: 

--- a/scripts/modis_download.py
+++ b/scripts/modis_download.py
@@ -48,11 +48,15 @@ def main():
     parser.add_option("-I", "--input", dest="input", action="store_true",
                       help="insert user and password from standard input")
     # password
-    parser.add_option("-P", "--password", dest="password",
+    parser.add_option("-P", "--password", dest="password", default=None,
                       help="password to connect to the server")
     # username
-    parser.add_option("-U", "--username", dest="user",
+    parser.add_option("-U", "--username", dest="user", default=None,
                       help="username to connect to the server")
+
+    # token
+    parser.add_option("-token", "--token", dest="token", default=None,
+                      help="user token to connect to the server")
     # tiles
     parser.add_option("-t", "--tiles", dest="tiles", default=None,
                       help="string of tiles separated with comma "
@@ -106,6 +110,10 @@ def main():
     parser.set_defaults(oneday=False)
     parser.set_defaults(debug=False)
     parser.set_defaults(jpg=False)
+    
+    user = None
+    password = None
+    token = None
 
     # return options and argument
     (options, args) = parser.parse_args()
@@ -123,17 +131,23 @@ def main():
         options.delta = 1
     if options.input:
         if sys.version_info.major == 3:
-            user = input("Username: ")
+            user = input("Username [type 'token' if you need to use token instead of user/login]: ")
         else:
             user = raw_input("Username: ")
-        password = getpass.getpass()
+        if user == "token":
+            token = getpass.getpass("Token: ")
+        else:
+            password = getpass.getpass("Password: ")
     else:
         user = options.user
         password = options.password
+        token = options.token
 
     # set modis object
-    modisOgg = downmodis.downModis(url=options.url, user=user,
+    modisOgg = downmodis.downModis(url=options.url, 
+                                   user=user,
                                    password=password,
+                                   token=token,
                                    destinationFolder=args[0],
                                    tiles=options.tiles, path=options.path,
                                    product=options.prod, today=options.today,


### PR DESCRIPTION
Recently, systems were updated to require a token for login instead of credentials (from [NASA forum](https://forum.earthdata.nasa.gov/)). Login and password authorization stopped working on NASA servers. Instead, it will introduce a bearer token authorization mechanism. I implemented a new authorization functionality and left the possibility of authorization by login and password for greater flexibility. Tested on MODIS product.


