### PR TITLE
Correctly extract token from netrc file and command line

### DIFF
--- a/scripts/modis_download.py
+++ b/scripts/modis_download.py
@@ -55,7 +55,7 @@ def main():
                       help="username to connect to the server")
 
     # token
-    parser.add_option("-token", "--token", dest="token", default=None,
+    parser.add_option("-T", "--token", dest="token", default=None,
                       help="user token to connect to the server")
     # tiles
     parser.add_option("-t", "--tiles", dest="tiles", default=None,


### PR DESCRIPTION
Resolves #156 

This fix will allow the token to load correctly from netrc file. Also, `modis_download.py` was corrected and allows to use `-T` or `--token` option for token case from command line.

For example:
```
    machine urs.earthdata.nasa.gov
    login token
    password YOURTOKEN
```

Thus, if you want to use a token instead of a username and password, you should use the word **token** as the username and the token value as a password.
